### PR TITLE
Added IMAGE as a new PointStyle for ScatterChart

### DIFF
--- a/achartengine/demo/org/achartengine/chartdemo/demo/chart/AbstractDemoChart.java
+++ b/achartengine/demo/org/achartengine/chartdemo/demo/chart/AbstractDemoChart.java
@@ -28,6 +28,7 @@ import org.achartengine.renderer.DefaultRenderer;
 import org.achartengine.renderer.SimpleSeriesRenderer;
 import org.achartengine.renderer.XYMultipleSeriesRenderer;
 import org.achartengine.renderer.XYSeriesRenderer;
+import org.achartengine.util.SerializableBitmap;
 
 /**
  * An abstract class for the demo charts to extend. It contains some methods for
@@ -77,17 +78,48 @@ public abstract class AbstractDemoChart implements IDemoChart {
     setRenderer(renderer, colors, styles);
     return renderer;
   }
-
+  
+  /**
+   * Builds an XY multiple series renderer.
+   * 
+   * @param colors the series rendering colors
+   * @param styles the series point styles
+   * @param bitmaps the series rendering images
+   * @return the XY multiple series renderers
+   */
+  protected XYMultipleSeriesRenderer buildRenderer(int[] colors, PointStyle[] styles, SerializableBitmap[] bitmaps) {
+    XYMultipleSeriesRenderer renderer = new XYMultipleSeriesRenderer();
+    setRenderer(renderer, colors, styles, bitmaps);
+    return renderer;
+  }
+  
   protected void setRenderer(XYMultipleSeriesRenderer renderer, int[] colors, PointStyle[] styles) {
+    renderer.setAxisTitleTextSize(16);
+    renderer.setChartTitleTextSize(20);
+    renderer.setLabelsTextSize(15);
+    renderer.setLegendTextSize(15);
+    renderer.setPointSize(5f); 
+    renderer.setMargins(new int[] { 20, 30, 15, 20 });
+    int length = colors.length;
+    for (int i = 0; i < length; i++) {
+      XYSeriesRenderer r = new XYSeriesRenderer();
+      r.setColor(colors[i]);
+      r.setPointStyle(styles[i]);
+      renderer.addSeriesRenderer(r);
+    }
+  }
+  
+  protected void setRenderer(XYMultipleSeriesRenderer renderer, int[] colors, PointStyle[] styles, SerializableBitmap[] bitmaps) {
     renderer.setAxisTitleTextSize(16);
     renderer.setChartTitleTextSize(20);
     renderer.setLabelsTextSize(15);
     renderer.setLegendTextSize(15);
     renderer.setPointSize(5f);
     renderer.setMargins(new int[] { 20, 30, 15, 20 });
-    int length = colors.length;
+    int length = bitmaps.length;
     for (int i = 0; i < length; i++) {
       XYSeriesRenderer r = new XYSeriesRenderer();
+      r.setBitmap(bitmaps[i]);
       r.setColor(colors[i]);
       r.setPointStyle(styles[i]);
       renderer.addSeriesRenderer(r);

--- a/achartengine/demo/org/achartengine/chartdemo/demo/chart/ScatterChart.java
+++ b/achartengine/demo/org/achartengine/chartdemo/demo/chart/ScatterChart.java
@@ -21,8 +21,10 @@ import java.util.Random;
 
 import org.achartengine.ChartFactory;
 import org.achartengine.chart.PointStyle;
+import org.achartengine.chartdemo.demo.R;
 import org.achartengine.renderer.XYMultipleSeriesRenderer;
 import org.achartengine.renderer.XYSeriesRenderer;
+import org.achartengine.util.SerializableBitmap;
 
 import android.content.Context;
 import android.content.Intent;
@@ -57,7 +59,7 @@ public class ScatterChart extends AbstractDemoChart {
    * @return the built intent
    */
   public Intent execute(Context context) {
-    String[] titles = new String[] { "Series 1", "Series 2", "Series 3", "Series 4", "Series 5" };
+    String[] titles = new String[] { "Series 1", "Series 2", "Series 3", "Series 4", "Series 5", "Series 6" };
     List<double[]> x = new ArrayList<double[]>();
     List<double[]> values = new ArrayList<double[]>();
     int count = 20;
@@ -73,12 +75,13 @@ public class ScatterChart extends AbstractDemoChart {
       x.add(xValues);
       values.add(yValues);
     }
-    int[] colors = new int[] { Color.BLUE, Color.CYAN, Color.MAGENTA, Color.LTGRAY, Color.GREEN };
+    int[] colors = new int[] { Color.BLUE, Color.CYAN, Color.MAGENTA, Color.LTGRAY, Color.GREEN, -1 };
     PointStyle[] styles = new PointStyle[] { PointStyle.X, PointStyle.DIAMOND, PointStyle.TRIANGLE,
-        PointStyle.SQUARE, PointStyle.CIRCLE };
-    XYMultipleSeriesRenderer renderer = buildRenderer(colors, styles);
-    setChartSettings(renderer, "Scatter chart", "X", "Y", -10, 30, -10, 51, Color.GRAY,
-        Color.LTGRAY);
+        PointStyle.SQUARE, PointStyle.CIRCLE, PointStyle.IMAGE };
+    SerializableBitmap mBitmap = new SerializableBitmap(context, R.drawable.achartengine, 30, 30);
+    SerializableBitmap[] bitmaps = new SerializableBitmap[] {null,null,null,null,null,mBitmap};
+    XYMultipleSeriesRenderer renderer = buildRenderer(colors, styles, bitmaps);
+    setChartSettings(renderer, "Scatter chart", "X", "Y", -10, 30, -10, 51, Color.GRAY, Color.LTGRAY);
     renderer.setXLabels(10);
     renderer.setYLabels(10);
     length = renderer.getSeriesRendererCount();

--- a/achartengine/src/org/achartengine/chart/PointStyle.java
+++ b/achartengine/src/org/achartengine/chart/PointStyle.java
@@ -19,8 +19,7 @@ package org.achartengine.chart;
  * The chart point style enumerator.
  */
 public enum PointStyle {
-  X("x"), CIRCLE("circle"), TRIANGLE("triangle"), SQUARE("square"), DIAMOND("diamond"), POINT(
-      "point");
+  X("x"), CIRCLE("circle"), TRIANGLE("triangle"), SQUARE("square"), DIAMOND("diamond"), POINT("point"), IMAGE("image");
 
   /** The point shape name. */
   private String mName;

--- a/achartengine/src/org/achartengine/chart/ScatterChart.java
+++ b/achartengine/src/org/achartengine/chart/ScatterChart.java
@@ -21,7 +21,9 @@ import org.achartengine.model.XYMultipleSeriesDataset;
 import org.achartengine.renderer.SimpleSeriesRenderer;
 import org.achartengine.renderer.XYMultipleSeriesRenderer;
 import org.achartengine.renderer.XYSeriesRenderer;
+import org.achartengine.util.SerializableBitmap;
 
+import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
@@ -113,6 +115,16 @@ public class ScatterChart extends XYChart {
         drawDiamond(canvas, paint, path, points.get(i), points.get(i + 1));
       }
       break;
+    case IMAGE:
+      SerializableBitmap sb = renderer.getBitmap();
+      Bitmap bitmap = null;
+      if(sb!=null){
+        bitmap = sb.getBitmap();
+      }
+      for (int i = 0; i < length; i += 2) {
+        drawImage(canvas, paint, points.get(i), points.get(i + 1), bitmap);
+      }
+      break;
     case POINT:
       for (int i = 0; i < length; i += 2) {
         canvas.drawPoint(points.get(i), points.get(i + 1), paint);
@@ -179,8 +191,18 @@ public class ScatterChart extends XYChart {
     case DIAMOND:
       drawDiamond(canvas, paint, new float[8], x + SHAPE_WIDTH, y);
       break;
+    case IMAGE:
+      SerializableBitmap sb = ((XYSeriesRenderer)renderer).getBitmap();
+      Bitmap bitmap = null;
+      if(sb!=null){
+        bitmap = sb.getBitmap();
+      }
+      drawImage(canvas, paint, x, y, bitmap);
+      break;
     case POINT:
       canvas.drawPoint(x + SHAPE_WIDTH, y, paint);
+      break;
+    default:
       break;
     }
   }
@@ -260,6 +282,23 @@ public class ScatterChart extends XYChart {
     path[6] = x + size;
     path[7] = y;
     drawPath(canvas, path, paint, true);
+  }
+
+  /**
+   * The graphical representation of an image.
+   * 
+   * @param canvas the canvas to paint to
+   * @param paint the paint to be used for drawing
+   * @param x the x value of the point the image should be drawn at
+   * @param y the y value of the point the image should be drawn at
+   * @param bitmap the image to be drawn
+   */
+  private void drawImage(Canvas canvas, Paint paint, float x, float y, Bitmap bitmap) {
+    if(bitmap==null){
+      canvas.drawRect(x - size, y - size, x + size, y + size, paint);
+    } else {
+      canvas.drawBitmap(bitmap, x-bitmap.getWidth()/2, y-bitmap.getHeight()/2, paint);
+    }
   }
 
   /**

--- a/achartengine/src/org/achartengine/renderer/XYSeriesRenderer.java
+++ b/achartengine/src/org/achartengine/renderer/XYSeriesRenderer.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.achartengine.chart.PointStyle;
 import org.achartengine.renderer.XYSeriesRenderer.FillOutsideLine.Type;
+import org.achartengine.util.SerializableBitmap;
 
 import android.graphics.Color;
 import android.graphics.Paint.Align;
@@ -55,6 +56,8 @@ public class XYSeriesRenderer extends SimpleSeriesRenderer {
   private Align mAnnotationsTextAlign = Align.CENTER;
   /** The annotations color. */
   private int mAnnotationsColor = DefaultRenderer.TEXT_COLOR;
+  /** The bitmap for the image to be drawn (for PointStyle.IMAGE) */
+  private SerializableBitmap mBitmap = null;
 
   /**
    * A descriptor for the line fill behavior.
@@ -227,7 +230,25 @@ public class XYSeriesRenderer extends SimpleSeriesRenderer {
   public void setPointStyle(PointStyle style) {
     mPointStyle = style;
   }
+  
+  /**
+   * Returns the bitmap.
+   * 
+   * @return the bitmap
+   */
+  public SerializableBitmap getBitmap() {
+    return mBitmap;
+  }
 
+  /**
+   * Sets the bitmap.
+   * 
+   * @param bitmaps the bitmap to be drawn
+   */
+  public void setBitmap(SerializableBitmap bitmaps) {
+    mBitmap = bitmaps;
+  }
+  
   /**
    * Returns the point stroke width in pixels.
    * 

--- a/achartengine/src/org/achartengine/util/SerializableBitmap.java
+++ b/achartengine/src/org/achartengine/util/SerializableBitmap.java
@@ -1,0 +1,48 @@
+package org.achartengine.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
+/**
+ * Represents a serializable bitmap
+ * @source http://stackoverflow.com/questions/6002800/android-serializable-problem
+ */
+public class SerializableBitmap implements Serializable {
+
+  private Bitmap mBitmap;
+
+  public SerializableBitmap(Context context, int resource) {
+    mBitmap = BitmapFactory.decodeResource(context.getResources(), resource);
+  }
+  public SerializableBitmap(Context context, int resource, int width, int height) {
+    mBitmap = BitmapFactory.decodeResource(context.getResources(), resource);
+    mBitmap = Bitmap.createScaledBitmap(mBitmap, width, height, true);
+  }
+
+  // Converts the Bitmap into a byte array for serialization
+  private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+    mBitmap.compress(Bitmap.CompressFormat.PNG, 0, byteStream);
+    byte bitmapBytes[] = byteStream.toByteArray();
+    out.write(bitmapBytes, 0, bitmapBytes.length);
+  }
+
+  // Deserializes a byte array representing the Bitmap and decodes it
+  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+    int b;
+    while((b = in.read()) != -1)
+      byteStream.write(b);
+    byte bitmapBytes[] = byteStream.toByteArray();
+    mBitmap = BitmapFactory.decodeByteArray(bitmapBytes, 0, bitmapBytes.length);
+  }
+  
+  public Bitmap getBitmap(){
+    return mBitmap;
+  }
+}


### PR DESCRIPTION
Prior: Users could choose different shapes (CIRCLE, DIAMOND, etc) as PointStyles for their different series in ScatterChart
Change: Added IMAGE as an additional option, along with the necessary code changes to support this new feature
After: Users can still use different shapes, but they can also use images for each series
